### PR TITLE
Fix use of operator

### DIFF
--- a/layers/attention.py
+++ b/layers/attention.py
@@ -158,7 +158,7 @@ class AttentionRNNCell(nn.Module):
             alignment = self.alignment_model(annots, rnn_output, atten)
         if mask is not None:
             mask = mask.view(memory.size(0), -1)
-            alignment.masked_fill_(1 - mask, -float("inf"))
+            alignment.masked_fill_(~mask, -float("inf"))
         # Windowing
         if not self.training and self.windowing:
             back_win = self.win_idx - self.win_back


### PR DESCRIPTION
Fixes: 
```
RuntimeError: Subtraction, the `-` operator, with a bool tensor is not supported. If you are trying to invert a mask, use the `~` or `bitwise_not()` operator instead.
```